### PR TITLE
feat: add eslint-disable command to gen-assets script

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "gen-assets": "rimraf static-assets && mkdir -p static-assets && cp build/static/js/*.js static-assets/main-v1.js && sed -i '1s/.*/\/\/ eslint-disable/' static-assets/main-v1.js",
+    "gen-assets": "rimraf static-assets && mkdir -p static-assets && cp build/static/js/*.js static-assets/main-v1.js && sed -i '1s@.*@\/\/ eslint-disable@' static-assets/main-v1.js",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
## Description

This PR  adds a command at the end of the script **gen-assets** to replace the first line of the generated bundle with `// eslint-disable`.

Motivations:
- remove the following comment about license, added automatically every time by react scripts: `/*! For license information please see main.xxxxxxxx.js.LICENSE.txt */`
- skip eslint check for this (minified) file to avoid breaking the build of Traefik Proxy docker image

## Preview

No visual changes.

## How to test?

The script should be able to run locally using `yarn build && yarn gen-assets`.
On macOS `''` must be added after `-i`, like this: `sed -i '' '1s@.*@\/\/ eslint-disable@' static-assets/main-v1.js`.

## Good PR checkboxes

- [x] Change has been tested
- [ ] Added/Updated tests
- [ ] Added/Updated documentation
- [ ] Content is fluid (well displayed in 768px screens)
- [ ] Issue is linked
- [x] Labels are set

## Good Review checkboxes

<details>
<summary> ℹ️  Copy the snippet and paste in the review field to fill it</summary>

```markdown
- [ ] I've tested the changes
- [ ] I've agreed on the unit tests
- [ ] I've checked the documentation (README)
- [ ] I've read the code and understood it
- [ ] I don't have any more questions
- [ ] I've described any optional improvements
```

</details>
