### PR TITLE
feat: extendable style

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Traefik Hub Button with WebComponents
 
-This Project aims to solve the issue to have a Hub buttonin the Traefik dashboard.
+This Project aims to solve the issue to have a Hub button in the Traefik dashboard.
 
 WebComponents are a way to define a custom component that runs as any other HTML component, so it can be used in any framework or even in pure HTML files, after importing the JS file with the component definition.
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import HubButton from 'components/HubButton'
 
-export const App = ({ background = '#54b4cd', color = '#ffffff' }: { background?: string; color?: string }) => {
-  return <HubButton background={background} color={color} />
+export const App = ({ style }: { style?: string }) => {
+  return <HubButton style={style} />
 }
 
 export default App

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import HubButton from 'components/HubButton'
 
-export const App = () => {
-  return <HubButton />
+export const App = ({ background = '#54b4cd', color = '#ffffff' }: { background?: string; color?: string }) => {
+  return <HubButton background={background} color={color} />
 }
 
 export default App

--- a/src/components/HubButton.tsx
+++ b/src/components/HubButton.tsx
@@ -3,13 +3,9 @@ import styled from 'styled-components'
 const StyledButton = styled.a`
   display: inline-block;
   padding: 13px 12px;
-
   border-radius: 8px;
-  background-color: #54b4cd;
-  color: #03192d;
   font-size: 1rem;
   font-weight: 700;
-  line-height: 1.38;
   text-decoration: none;
 
   position: relative;
@@ -20,14 +16,13 @@ const StyledButton = styled.a`
   }
 
   &:hover {
-    background-color: #7fc7d9;
-    transition: background-color 0.1s;
+    filter: brightness(110%);
   }
 `
 
-const HubButton = () => {
+const HubButton = ({ background = '#54b4cd', color = '#ffffff' }: { background: string; color: string }) => {
   return (
-    <StyledButton href="https://traefik.io/upgrade-traefik" target="_blank">
+    <StyledButton href="https://traefik.io/upgrade-traefik" target="_blank" style={{ background, color }}>
       Upgrade
     </StyledButton>
   )

--- a/src/components/HubButton.tsx
+++ b/src/components/HubButton.tsx
@@ -1,5 +1,14 @@
 import styled from 'styled-components'
 
+const parseInlineStyle = (style: string) => {
+  const template = document.createElement('template')
+  template.setAttribute('style', style)
+  return Object.entries(template.style)
+    .filter(([key]) => !/^[0-9]+$/.test(key))
+    .filter(([, value]) => Boolean(value))
+    .reduce((acc, [key, value]) => ({ ...acc, [key]: value }), {})
+}
+
 const StyledButton = styled.a`
   display: inline-block;
   padding: 13px 12px;
@@ -7,7 +16,8 @@ const StyledButton = styled.a`
   font-size: 1rem;
   font-weight: 700;
   text-decoration: none;
-
+  background-color: #54b4cd;
+  color: #ffffff;
   position: relative;
 
   label {
@@ -20,9 +30,13 @@ const StyledButton = styled.a`
   }
 `
 
-const HubButton = ({ background = '#54b4cd', color = '#ffffff' }: { background: string; color: string }) => {
+const HubButton = ({ style }: { style?: string }) => {
   return (
-    <StyledButton href="https://traefik.io/upgrade-traefik" target="_blank" style={{ background, color }}>
+    <StyledButton
+      href="https://traefik.io/upgrade-traefik"
+      target="_blank"
+      style={style ? parseInlineStyle(style) : {}}
+    >
       Upgrade
     </StyledButton>
   )


### PR DESCRIPTION
## Description

Make it possible to extend the style for the button or to override existing style, like so:

`<hub-button-app style="color: red"></hub-button-app>`

<img width="129" alt="image" src="https://github.com/user-attachments/assets/df135eb3-12eb-4759-a3a6-099f0365d661" />

Default style:
<img width="97" alt="image" src="https://github.com/user-attachments/assets/6a960faa-5b22-4665-98b4-e906302bbb6b" />
